### PR TITLE
fix: contacts/new で一つのタグを選択すると他既存タグが全て消えるバグの修正

### DIFF
--- a/components/contacts/form/requiredForm.tsx
+++ b/components/contacts/form/requiredForm.tsx
@@ -59,7 +59,10 @@ export default function RequiredForm({ meetupId, tags }: Props) {
               key={t.id}
               onClick={() => {
                 setSelectTags([...selectTags, t]);
-                setContactTags([]);
+                const filterContactsTags = contactTags.filter(
+                  (c) => t.id != c.id,
+                );
+                setContactTags([...filterContactsTags]);
                 console.log("clicked");
               }}
             >


### PR DESCRIPTION
Fixes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag removal behavior in the contacts form. Clicking a tag now removes only the selected tag instead of clearing all tags at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->