### PR TITLE
refactor: deleteTagの改善

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+version: 2
+
 pull_requests:
   language: ja
   instructions: |

--- a/app/(private)/dashboard/tags/[tagId]/action.ts
+++ b/app/(private)/dashboard/tags/[tagId]/action.ts
@@ -1,4 +1,5 @@
 "use server";
+
 import { redirect } from "next/navigation";
 
 import type { TagErrors } from "@/type/private/tags/tags";
@@ -14,6 +15,7 @@ const tagValidation = (formData: FormData) => {
   };
   return tagSchema.safeParse(rawFormData);
 };
+
 export const updateTag = async (
   tagId: string,
   _: ActionState<TagErrors>,
@@ -68,8 +70,8 @@ export const deleteTag = async (
         },
       };
     await prisma.tag.delete({
-        where: { id: tagId, userId: user.id },
-      });
+      where: { id: tagId, userId: user.id },
+    });
   } catch (error) {
     console.error(error);
     return {


### PR DESCRIPTION
deleteTagではtransaction を使って contactsTagを消した後にtagを消していた

しかし、そもそもcontact sTagにはtagへcascade されていたためトランザクションは不要となる

そのため、transaction からdelete.tag単体の呼び出しに変更

Close #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined tag deletion flow: deleting a tag now performs a single direct removal while preserving existing error handling and redirect behavior.

* **Chores**
  * Configuration updated with schema and version metadata for tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->