### PR TITLE
updateTagform の正式実装

### DIFF
--- a/components/tag/form/updateTag.tsx
+++ b/components/tag/form/updateTag.tsx
@@ -1,9 +1,25 @@
 "use client";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useActionState } from "react";
+import { useForm } from "react-hook-form";
 
 import type { Tag } from "@/type/private/tags/tags";
 
 import { updateTag } from "@/app/(private)/dashboard/tags/[tagId]/action";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  tagSchema,
+  type TagSchema,
+} from "@/validations/private/tagValidations";
 
 type UpdateTagFormProps = {
   tag: Tag;
@@ -15,17 +31,42 @@ export const UpdateTagForm = ({ tag }: UpdateTagFormProps) => {
     errors: {},
   });
 
+  const form = useForm<TagSchema>({
+    resolver: zodResolver(tagSchema),
+    defaultValues: {
+      name: tag.name,
+    },
+    mode: "onChange",
+  });
+  const isDisabled = !form.formState.isValid || isPending;
+  const buttonLabel = isPending
+    ? "送信中"
+    : form.formState.isValid
+      ? "送信"
+      : "入力してください";
   if (isPending) {
     return <div>pending</div>;
   }
   return (
-    <form action={action}>
-      {state.errors.id}
-      {state.errors.auth}
-      {state.errors.server}
-      <input type="text" name="name" defaultValue={tag.name} />
-      {state.errors.tag}
-      <button type="submit">確定</button>
-    </form>
+    <Form {...form}>
+      <form action={action}>
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>tag名</FormLabel>
+              <FormControl>
+                <Input {...field} defaultValue={form.getValues("name")} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={isDisabled}>
+          {buttonLabel}
+        </Button>
+      </form>
+    </Form>
   );
 };

--- a/components/tag/form/updateTag.tsx
+++ b/components/tag/form/updateTag.tsx
@@ -26,7 +26,8 @@ type UpdateTagFormProps = {
 };
 export const UpdateTagForm = ({ tag }: UpdateTagFormProps) => {
   const updateTagWithId = updateTag.bind(null, tag.id);
-  const [state, action, isPending] = useActionState(updateTagWithId, {
+  //TODO state を潰している(action側が未整備のため MVPでのrelease後 refactoring を行ったらupdateする)
+  const [_, action, isPending] = useActionState(updateTagWithId, {
     success: false,
     errors: {},
   });

--- a/components/tag/form/updateTag.tsx
+++ b/components/tag/form/updateTag.tsx
@@ -58,7 +58,7 @@ export const UpdateTagForm = ({ tag }: UpdateTagFormProps) => {
             <FormItem>
               <FormLabel>tag名</FormLabel>
               <FormControl>
-                <Input {...field} defaultValue={form.getValues("name")} />
+                <Input {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/validations/private/tagValidations.ts
+++ b/validations/private/tagValidations.ts
@@ -1,7 +1,10 @@
 import z from "zod";
 
 export const tagSchema = z.object({
-  name: z.string().min(1).max(10),
+  name: z
+    .string()
+    .min(1, "tag名を入力してください")
+    .max(20, "20文字以内にしてください"),
 });
 
 export type TagSchema = z.infer<typeof tagSchema>;


### PR DESCRIPTION
Close #173

## 概要
仮実装であったupdate tag form をRHF + zod + useActionStateの正式実装を行った

## review対象外について
- design
- action  state(`_`としている部分) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タグ名の入力上限を10文字から20文字に拡大しました
  * バリデーションエラーメッセージを日本語で表示するようにしました
  * フォームを構造化して反応的な入力検証を導入しました

* **改善**
  * 送信状態表示を改善（送信中／送信／入力してください 等のラベルと無効化制御）
  * 既存の更新処理フローは維持しつつ新しいフォーム構成に統合しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->